### PR TITLE
CDP 576 - Toggle Number of Results Displaying

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -17,9 +17,8 @@ import {
 import { queryRequest } from '../utils/api';
 import { queryBuilder } from '../utils/helpers';
 
-export const calculatePages = ( _total, _currentPage ) => {
+export const calculatePages = ( _total, _currentPage, pageSize = 1 ) => {
   const total = _total;
-  const pageSize = 12;
   const currentPage = _currentPage;
   const totalPages = Math.ceil( total / pageSize );
 
@@ -87,7 +86,8 @@ export const createRequest = () => async ( dispatch, getState ) => {
   const currentState = getState();
   try {
     response = await queryRequest( {
-      size: 12,
+      // size: 12,
+      size: 1,
       body: queryBuilder( currentState )
     } );
   } catch ( err ) {
@@ -107,65 +107,8 @@ export const createRequest = () => async ( dispatch, getState ) => {
   } );
 };
 
-export const previousRequest = () => async ( dispatch, getState ) => {
-  const OFFSET = 12;
-  dispatch( showLoading() );
-  dispatch( { type: SEARCH_PAGE_PENDING } );
-
-  let response;
-  const pageOffset = getState().search.currentPage * OFFSET;
-
-  try {
-    response = await queryRequest( {
-      body: queryBuilder( getState() ),
-      from: pageOffset - OFFSET,
-      size: 12
-    } );
-  } catch ( err ) {
-    return dispatch( { type: SEARCH_PAGE_FAILED } );
-  }
-
-  dispatch( hideLoading() );
-  window.scrollTo( 0, 0 );
-  return dispatch( {
-    type: SEARCH_PAGE_SUCCESS,
-    payload: {
-      response,
-      ...calculatePages( response.hits.total, getState().search.currentPage - 1 )
-    }
-  } );
-};
-
-export const nextRequest = () => async ( dispatch, getState ) => {
-  const OFFSET = 12;
-  dispatch( showLoading() );
-  dispatch( { type: SEARCH_PAGE_PENDING } );
-
-  let response;
-  try {
-    response = await queryRequest( {
-      body: queryBuilder( getState() ),
-      from: getState().search.currentPage * OFFSET,
-      size: 12
-    } );
-  } catch ( err ) {
-    dispatch( hideLoading() );
-    return dispatch( { type: SEARCH_PAGE_FAILED } );
-  }
-
-  dispatch( hideLoading() );
-  window.scrollTo( 0, 0 );
-  return dispatch( {
-    type: SEARCH_PAGE_SUCCESS,
-    payload: {
-      response,
-      ...calculatePages( response.hits.total, getState().search.currentPage + 1 )
-    }
-  } );
-};
-
-export const targetRequest = page => async ( dispatch, getState ) => {
-  let offset = 12;
+export const targetRequest = ( page, pageSize = 1 ) => async ( dispatch, getState ) => {
+  let offset = pageSize;
   const pageOffset = page * offset;
   offset = pageOffset - offset;
   dispatch( showLoading() );
@@ -176,7 +119,7 @@ export const targetRequest = page => async ( dispatch, getState ) => {
     response = await queryRequest( {
       body: queryBuilder( getState() ),
       from: offset,
-      size: 12
+      size: pageSize
     } );
   } catch ( err ) {
     dispatch( hideLoading() );
@@ -190,12 +133,12 @@ export const targetRequest = page => async ( dispatch, getState ) => {
     payload: {
       response,
       current: page,
-      ...calculatePages( response.hits.total, page )
+      ...calculatePages( response.hits.total, page, pageSize )
     }
   } );
 };
 
-export const sortRequest = sortType => async ( dispatch, getState ) => {
+export const sortRequest = ( sortType, pageSize = 1 ) => async ( dispatch, getState ) => {
   dispatch( showLoading() );
   dispatch( {
     type: SEARCH_SORT_PENDING,
@@ -210,7 +153,7 @@ export const sortRequest = sortType => async ( dispatch, getState ) => {
   try {
     response = await queryRequest( {
       body: queryBuilder( getState() ),
-      size: 12
+      size: pageSize
     } );
   } catch ( err ) {
     dispatch( hideLoading() );
@@ -222,7 +165,7 @@ export const sortRequest = sortType => async ( dispatch, getState ) => {
     type: SEARCH_SORT_SUCCESS,
     payload: {
       response,
-      ...calculatePages( response.hits.total, 1 )
+      ...calculatePages( response.hits.total, 1, pageSize )
     }
   } );
 };
@@ -244,13 +187,12 @@ export const updateSizeRequest = newSize => async ( dispatch, getState ) => {
   }
 
   dispatch( hideLoading() );
+
   return dispatch( {
     type: SEARCH_REQUEST_SUCCESS,
     payload: {
       response,
-      ...calculatePages( response.hits.total, 1 ),
-      sort: 'relevance',
-      currentQuery: currentState.search.query
+      ...calculatePages( response.hits.total, 1, newSize )
     }
   } );
 };

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -226,3 +226,32 @@ export const sortRequest = sortType => async ( dispatch, getState ) => {
     }
   } );
 };
+
+export const updateSizeRequest = newSize => async ( dispatch, getState ) => {
+  dispatch( showLoading() );
+  dispatch( { type: SEARCH_REQUEST_PENDING } );
+
+  let response;
+  const currentState = getState();
+  try {
+    response = await queryRequest( {
+      size: newSize,
+      body: queryBuilder( currentState )
+    } );
+  } catch ( err ) {
+    dispatch( hideLoading() );
+    return dispatch( { type: SEARCH_REQUEST_FAILED } );
+  }
+
+  dispatch( hideLoading() );
+  return dispatch( {
+    type: SEARCH_REQUEST_SUCCESS,
+    payload: {
+      response,
+      ...calculatePages( response.hits.total, 1 ),
+      sort: 'relevance',
+      currentQuery: currentState.search.query
+    }
+  } );
+};
+

--- a/src/components/Results/ResultsHeader/ResultsHeader.js
+++ b/src/components/Results/ResultsHeader/ResultsHeader.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { object, func, string } from 'prop-types';
 import { connect } from 'react-redux';
 import { numberWithCommas } from '../../../utils/helpers';
-import { sortRequest } from '../../../actions/search';
+import { sortRequest, updateSizeRequest } from '../../../actions/search';
 import { Form, Select, Dropdown } from 'semantic-ui-react';
 import ResultsToggleView from '../ResultsToggleView';
 import './ResultsHeader.css';
@@ -21,17 +21,16 @@ class ResultsHeader extends Component {
   }
 
   handleOnChange( event, { value } ) {
-    this.props.sortRequest( value );
+    const { pageSize } = this.props.search;
+    this.props.sortRequest( value, pageSize );
   }
 
   toggleNumberOfResults( e, { value } ) {
-    console.log( this );
-    console.log( 'value: ', value );
+    this.props.updateSizeRequest( value );
   }
 
   render() {
     const {
-      currentPage,
       total,
       startIndex,
       endIndex,
@@ -42,10 +41,10 @@ class ResultsHeader extends Component {
     const resultItemsEnd = endIndex + 1;
 
     const numOfResultsDisplay = [
-      { text: '12', value: 12 },
-      { text: '24', value: 24 },
-      { text: '36', value: 36 },
-      { text: '48', value: 48 }
+      { text: '1', value: 1 },
+      { text: '2', value: 2 },
+      { text: '4', value: 4 },
+      { text: '8', value: 8 }
     ];
 
     if ( this.props.search.response.took && this.props.search.response.hits.hits.length ) {
@@ -63,23 +62,16 @@ class ResultsHeader extends Component {
                 />
               </Form.Group>
             </Form>
+            <div className="results_total">
+              { resultItemsStart }-{ resultItemsEnd } of { numberWithCommas( total ) } |
+              Show: <Dropdown
+                defaultValue={ numOfResultsDisplay[0].value }
+                options={ numOfResultsDisplay }
+                className="results_total_numOfResults"
+                onChange={ this.toggleNumberOfResults }
+              />
+            </div>
 
-            { currentPage === 1 ? (
-              <div className="results_total">
-                { resultItemsStart }-{ resultItemsEnd } of { numberWithCommas( total ) } |
-                Show:
-                <Dropdown
-                  defaultValue={ numOfResultsDisplay[0].value }
-                  options={ numOfResultsDisplay }
-                  className="results_total_numOfResults"
-                  onChange={ this.toggleNumberOfResults }
-                />
-              </div>
-            ) : (
-              <p className="results_total">
-                Page { currentPage } of about { total } results
-              </p>
-            ) }
           </div>
         </div>
       );
@@ -96,8 +88,9 @@ const mapStateToProps = state => ( {
 ResultsHeader.propTypes = {
   search: object,
   sortRequest: func,
+  updateSizeRequest: func,
   toggleView: func,
   currentView: string
 };
 
-export default connect( mapStateToProps, { sortRequest } )( ResultsHeader );
+export default connect( mapStateToProps, { sortRequest, updateSizeRequest } )( ResultsHeader );

--- a/src/components/Results/ResultsHeader/ResultsHeader.js
+++ b/src/components/Results/ResultsHeader/ResultsHeader.js
@@ -3,50 +3,78 @@ import { object, func, string } from 'prop-types';
 import { connect } from 'react-redux';
 import { numberWithCommas } from '../../../utils/helpers';
 import { sortRequest } from '../../../actions/search';
-// import { Form, Select } from 'semantic-ui-react';
+import { Form, Select, Dropdown } from 'semantic-ui-react';
 import ResultsToggleView from '../ResultsToggleView';
 import './ResultsHeader.css';
 
 /** **
 TEMP
 **** */
-// const options = [{ key: 1, text: 'Relevance', value: 'relevance' }, { key: 2, text: 'Recent', value: 'published' }];
+const options = [{ key: 1, text: 'Relevance', value: 'relevance' }, { key: 2, text: 'Recent', value: 'published' }];
 /** * */
 
 class ResultsHeader extends Component {
   constructor( props ) {
     super( props );
     this.handleOnChange = this.handleOnChange.bind( this );
+    this.toggleNumberOfResults = this.toggleNumberOfResults.bind( this );
   }
 
   handleOnChange( event, { value } ) {
     this.props.sortRequest( value );
   }
 
+  toggleNumberOfResults( e, { value } ) {
+    console.log( this );
+    console.log( 'value: ', value );
+  }
+
   render() {
-    const { currentPage, total } = this.props.search;
+    const {
+      currentPage,
+      total,
+      startIndex,
+      endIndex,
+      sort
+    } = this.props.search;
     const { toggleView, currentView } = this.props;
-    console.log( this.props.search );
+    const resultItemsStart = startIndex + 1;
+    const resultItemsEnd = endIndex + 1;
+
+    const numOfResultsDisplay = [
+      { text: '12', value: 12 },
+      { text: '24', value: 24 },
+      { text: '36', value: 36 },
+      { text: '48', value: 48 }
+    ];
 
     if ( this.props.search.response.took && this.props.search.response.hits.hits.length ) {
       return (
         <div>
           <ResultsToggleView toggle={ toggleView } currentView={ currentView } />
           <div className="results_header">
-            { /* <Form>
-              <Form.Group className="results_sort">
+            <Form className="results_sort">
+              <Form.Group>
                 <Form.Field
                   control={ Select }
-                  label="Sort By"
                   value={ sort }
                   options={ options }
                   onChange={ this.handleOnChange }
                 />
               </Form.Group>
-            </Form> */ }
+            </Form>
 
             { currentPage === 1 ? (
-              <p className="results_total">About { numberWithCommas( total ) } results</p>
+              <div className="results_total">
+                { resultItemsStart }-{ resultItemsEnd } of { numberWithCommas( total ) } |
+                Show:
+                <Dropdown
+                  defaultValue={ numOfResultsDisplay[0].value }
+                  options={ numOfResultsDisplay }
+                  className="results_total_numOfResults"
+                  onChange={ this.toggleNumberOfResults }
+                />
+              </div>
             ) : (
               <p className="results_total">
                 Page { currentPage } of about { total } results

--- a/src/components/Results/ResultsHeader/ResultsHeader.js
+++ b/src/components/Results/ResultsHeader/ResultsHeader.js
@@ -26,31 +26,33 @@ class ResultsHeader extends Component {
   render() {
     const { currentPage, total } = this.props.search;
     const { toggleView, currentView } = this.props;
+    console.log( this.props.search );
 
     if ( this.props.search.response.took && this.props.search.response.hits.hits.length ) {
       return (
-        <div className="results_header">
-          { currentPage === 1 ? (
-            <p className="results_total">About { numberWithCommas( total ) } results</p>
-          ) : (
-            <p className="results_total">
-              Page { currentPage } of about { total } results
-            </p>
-          ) }
-
-          { /* <Form>
-            <Form.Group className="results_sort">
-              <Form.Field
-                control={ Select }
-                label="Sort By"
-                value={ sort }
-                options={ options }
-                onChange={ this.handleOnChange }
-              />
-            </Form.Group>
-          </Form> */ }
-
+        <div>
           <ResultsToggleView toggle={ toggleView } currentView={ currentView } />
+          <div className="results_header">
+            { /* <Form>
+              <Form.Group className="results_sort">
+                <Form.Field
+                  control={ Select }
+                  label="Sort By"
+                  value={ sort }
+                  options={ options }
+                  onChange={ this.handleOnChange }
+                />
+              </Form.Group>
+            </Form> */ }
+
+            { currentPage === 1 ? (
+              <p className="results_total">About { numberWithCommas( total ) } results</p>
+            ) : (
+              <p className="results_total">
+                Page { currentPage } of about { total } results
+              </p>
+            ) }
+          </div>
         </div>
       );
     }

--- a/src/components/Results/ResultsHeader/ResultsHeader.scss
+++ b/src/components/Results/ResultsHeader/ResultsHeader.scss
@@ -6,17 +6,11 @@
   &_header {
     display: flex;
     justify-content: space-between;
+    margin-top: 1em;
+    margin-bottom: 1em;
     @media (max-width: 767px) {
       flex-direction: column;
-    }
-
-    & > p {
-      flex: 0.8;
-    }
-
-    & > form {
-      flex: 0.2;
-    }    
+    }   
   }
 
 
@@ -24,6 +18,14 @@
     @media (max-width: 767px) {
       order: 2;
     }  
+
+    &_numOfResults {
+
+      &.ui.dropdown .menu {
+        border: none;
+        border-radius: 0;
+      }
+    }
   }
 
 
@@ -36,6 +38,10 @@
     &.ui.form {
       margin: 0;
 
+      .fields {
+        margin: 0;
+      }
+
       .field {
         flex: 1;
       }
@@ -47,15 +53,20 @@
       }
 
       .ui.selection.dropdown {
-        padding-left: 0;
-        padding-right: 0;
+        padding: 0;
         margin: 0;
+        min-height: 0;
         border: none;
-        border-bottom: 1px solid #000;
         border-radius: 0;
 
         .dropdown.icon {
-          padding-right: 0;
+          position: relative;
+          top: auto;
+          right: auto;
+          float: none;          
+          display: inline-block;    
+          padding: 0;
+          margin: 0 0 0 1em;
         }
 
         &.active {

--- a/src/components/Results/ResultsPagination/ResultsPagination.js
+++ b/src/components/Results/ResultsPagination/ResultsPagination.js
@@ -7,7 +7,7 @@ import './ResultsPagination.css';
 import { Pagination } from 'semantic-ui-react';
 
 class ResultsPagination extends Component {
-  handlePaginationChange = ( e, { activePage } ) => this.props.targetRequest( activePage );
+  handlePaginationChange = ( e, { activePage } ) => this.props.targetRequest( activePage, this.props.search.pageSize );
 
   render() {
     if ( this.props.search.totalPages > 1 ) {

--- a/src/components/Results/ResultsToggleView/ResultsToggleView.scss
+++ b/src/components/Results/ResultsToggleView/ResultsToggleView.scss
@@ -1,6 +1,8 @@
 @import "../../../assets/styles/colors.scss";
 
 .results_toggleView {
+  display: flex;
+  justify-content: flex-end;
   @media screen and (max-width: 767px) {
     z-index: 3;
     margin-top: 1em;


### PR DESCRIPTION
- includes the result items & total displaying (ie: '1-4 of 6')
- added number of results displaying toggle dropdown
  -- for testing, currently dropdown toggles btwn 1, 2, 4, 8 (since only 6 results from API currently when searching for '*')
  -- each page showing 1 result as default
  -- /actions/search.js > calculatePages, createRequest, targetRequest, sortRequest must be UPDATED
      --- update 'size', 'pageSize' default values to 12