### PR TITLE
Results Page - Language Toggle Props Update

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -86,6 +86,7 @@ export const createRequest = () => async ( dispatch, getState ) => {
 
   let response;
   const currentState = getState();
+
   try {
     response = await queryRequest( {
       size: PAGE_SIZE,

--- a/src/components/Results/Results.js
+++ b/src/components/Results/Results.js
@@ -15,10 +15,14 @@ class Results extends Component {
   constructor( props ) {
     super( props );
     this.state = {
-      view: 'gallery'
+      view: 'gallery',
     };
 
     this.toggleView = this.toggleView.bind( this );
+  }
+
+  shouldComponentUpdate( nextProps, nextState ) {
+    return this.props.search.response.hits !== nextProps.search.response.hits;
   }
 
   toggleView( e ) {

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -3,3 +3,4 @@ import ReduxThunk from 'redux-thunk';
 import reducers from '../reducers';
 
 export default applyMiddleware( ReduxThunk )( createStore )( reducers );
+


### PR DESCRIPTION
- add shouldComponentUpdate method to Results.js to compare props (search.response.hits)
- will only update if props diff
- resolves phantom placeholder result items displaying when toggling between languages and number of Results different (ie: English 5 results to Arabic 3 results)